### PR TITLE
updated icon-unknown link for django 1.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,15 @@ But I also plan to add other features I developed for my own projects.
 Usage
 -----
 
+Prior to 1.5:
+
 It’s only compatible with Django 1.7.2 to 1.7.8 (I tested) and probably 1.8.
 Don’t even try with previous versions, django-super-inlines relies on changes
 that happened between 1.6 and 1.7.2.
+
+From 1.5:
+
+compatible with 1.9.
 
 For design reasons, you can’t nest inlines inside tabular inlines,
 only inside stacked inlines.

--- a/super_inlines/__init__.py
+++ b/super_inlines/__init__.py
@@ -1,2 +1,2 @@
-__version__ = (0, 1, 4)
+__version__ = (0, 1, 5)
 version_string = '.'.join(str(n) for n in __version__)

--- a/super_inlines/templates/admin/edit_inline/tabular.html
+++ b/super_inlines/templates/admin/edit_inline/tabular.html
@@ -16,7 +16,7 @@
                      <th{% if forloop.first %} colspan="2"{% endif %}{% if field.required %} class="required"{% endif %}>
                        {{ field.label|capfirst }}
                        {% if field.help_text %}
-                         <img src="{% static "admin/img/icon-unknown.gif" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" />
+                         <img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" />
                        {% endif %}
                      </th>
                    {% endif %}


### PR DESCRIPTION
This fixes #16 

I updated the link from .gif to .svg.
Bumped the project version to 1.5.
Updated documentation.
