### PR TITLE
Fix RemovedInDjango20Warning

### DIFF
--- a/super_inlines/templatetags/super_inlines.py
+++ b/super_inlines/templatetags/super_inlines.py
@@ -9,7 +9,7 @@ from ..admin import SuperInlineModelAdmin
 register = Library()
 
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def get_sub_inline_formsets(context, inline, original, index, is_template):
     if not isinstance(inline, SuperInlineModelAdmin):
         return ()


### PR DESCRIPTION
Fix RemovedInDjango20Warning: assignment_tag() is deprecated. Use simple_tag() instead. 
Appeared while running:  
  python -Wall manage.py test
