### PR TITLE
Update reference to icon-unknown.svg

### DIFF
--- a/super_inlines/templates/admin/edit_inline/tabular.html
+++ b/super_inlines/templates/admin/edit_inline/tabular.html
@@ -16,7 +16,7 @@
                      <th{% if forloop.first %} colspan="2"{% endif %}{% if field.required %} class="required"{% endif %}>
                        {{ field.label|capfirst }}
                        {% if field.help_text %}
-                         <img src="{% static "admin/img/icon-unknown.gif" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" />
+                         <img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" />
                        {% endif %}
                      </th>
                    {% endif %}


### PR DESCRIPTION
Since django 1.11, `icon-unknown.gif` has been replaced with `icon-unknown.svg`. Because of this broken reference, `super_inlines` will crash when using some form of `ManifestStorage` on django >= 1.11.