### PR TITLE
change `assignment_tag` to `simple_tag`

### DIFF
--- a/super_inlines/templatetags/super_inlines.py
+++ b/super_inlines/templatetags/super_inlines.py
@@ -9,7 +9,7 @@ from ..admin import SuperInlineModelAdmin
 register = Library()
 
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def get_sub_inline_formsets(context, inline, original, index, is_template):
     if not isinstance(inline, SuperInlineModelAdmin):
         return ()


### PR DESCRIPTION
assignment_tag is deprecated and will be removed in django 2.0, simple_tag is the recommended replacement